### PR TITLE
Fixed: utmdebug flag when set causes 500

### DIFF
--- a/RailsApplication1/app/controllers/ga_controller.rb
+++ b/RailsApplication1/app/controllers/ga_controller.rb
@@ -135,7 +135,7 @@ class GaController < ApplicationController
     # If the debug parameter is on, add a header to the response that contains
     # the url that was used to contact Google Analytics.
     unless params[:utmdebug].blank?
-      request.headers["X-GA-MOBILE-URL:"] = utmurl
+      response.headers["X-GA-MOBILE-URL"] = utm_url
     end
     # Finally write the gif data to the response.
     write_gif_data()


### PR DESCRIPTION
Setting the utmdebug to any value causes a 500 to appear, this is due to:

a) The X-GA-MOBILE-URL header value is being assigned to the request rather than the response, and
b) utmurl is being used instead of utm_url.
