### PR TITLE
Fixed: track_pageview is not setting response cookie values

### DIFF
--- a/RailsApplication1/app/controllers/ga_controller.rb
+++ b/RailsApplication1/app/controllers/ga_controller.rb
@@ -116,7 +116,10 @@ class GaController < ApplicationController
     visitor_id = get_visitor_id(request.env["HTTP_X_DCMGUID"], account, user_agent, cookie)
 
     # Always try and add the cookie to the response.
-    request.cookies[COOKIE_NAME] = {:value => visitor_id, :expires => COOKIE_PERSISTENCE.to_i + timestamp, :path => COOKIE_PATH}
+    cookie_value = visitor_id
+    cookie_expires = Time.at(COOKIE_PERSISTENCE.to_i + timestamp)
+    cookie_path = COOKIE_PATH
+    cookies[COOKIE_NAME] = {:value => cookie_value, :expires => cookie_expires, :path => COOKIE_PATH}
 
     # Construct the gif hit url.
     utm_url = UTM_GIF_LOCATION + "?" +


### PR DESCRIPTION
The utm_gif wasn't setting response cookies back to the browser.

Changed the logic to update the response cookies rather than the request cookies.