### PR TITLE
send_request_to_ga was attempting to join nil strings

### DIFF
--- a/RailsApplication1/app/controllers/ga_controller.rb
+++ b/RailsApplication1/app/controllers/ga_controller.rb
@@ -84,8 +84,10 @@ class GaController < ApplicationController
 
     #puts "--------sending request to GA-----------------------"
     #puts utmurl
-    open(utmurl,"User-Agent" => request.env["HTTP_USER_AGENT"],
-          "Header" => ("Accepts-Language: " + request.env["HTTP_ACCEPT_LANGUAGE"]))
+    user_agent = request.env["HTTP_USER_AGENT"] || ''
+    user_language = request.env["HTTP_ACCEPT_LANGUAGE"] || ''
+    open(utmurl, "User-Agent" => user_agent,
+      "Header" => ("Accepts-Language: " + user_language))
   end
 
   # Track a page view, updates all the cookies and campaign tracker,


### PR DESCRIPTION
send_request_to_ga was using ENV values and attempting to join them together, as some of the values could be nil, this raised a few exceptions.

Changed code to replace nil values with an empty string to prevent these errors.